### PR TITLE
Enable namespace in bucklescript config

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -15,7 +15,7 @@
   ],
   "bs-dependencies": [],
   "bs-dev-dependencies": ["bs-jest"],
-  "namespace": false,
+  "namespace": true,
   "package-specs": ["commonjs", "es6"],
   "refmt": 3
 }


### PR DESCRIPTION
I want to propose this because currently, I can't get type information when working on `nice.re` file (this is a known limitation of bucklescript/merlin). I asked chenglou on Discord and he suggested that I should enable namespace (I have no ideas what does it mean).

And by the way, all new bucklescript projects have namespace enabled by default. 