### PR TITLE
Implement splitSelector in pure reason

### DIFF
--- a/__tests__/nice_test.re
+++ b/__tests__/nice_test.re
@@ -51,7 +51,7 @@ describe("Nice", () => {
     expect(serialized_global_cache()) |> toMatchSnapshot;
   });
   test("splitSelector", () =>
-    expect(Nice.splitSelector(".a, span:hover, &:matches(h1, h2)"))
-    |> toEqual([|".a", " span:hover", " &:matches(h1, h2)"|])
+    expect(Nice.splitSelector(".a, span:hover, &:matches(h1, h2, h3, h4)"))
+    |> toEqual([|".a", " span:hover", " &:matches(h1, h2, h3, h4)"|])
   );
 });

--- a/__tests__/nice_test.re
+++ b/__tests__/nice_test.re
@@ -50,4 +50,8 @@ describe("Nice", () => {
     global("html, body", [Padding(Px(20))]);
     expect(serialized_global_cache()) |> toMatchSnapshot;
   });
+  test("splitSelector", () =>
+    expect(Nice.splitSelector(".a, span:hover, &:matches(h1, h2)"))
+    |> toEqual([|".a", " span:hover", " &:matches(h1, h2)"|])
+  );
 });

--- a/lib/es6/__tests__/nice_test.js
+++ b/lib/es6/__tests__/nice_test.js
@@ -113,12 +113,19 @@ describe("Nice", (function () {
                                 serialized_rule_cache(/* () */0)
                               ]));
               }));
-        return Jest.test("global", (function () {
-                      Nice.$$global("html, body", /* :: */[
-                            /* Padding */Block.__(18, [/* Px */Block.__(0, [20])]),
-                            /* [] */0
-                          ]);
-                      return Jest.Expect[/* toMatchSnapshot */16](Jest.Expect[/* expect */0](serialized_global_cache(/* () */0)));
+        Jest.test("global", (function () {
+                Nice.$$global("html, body", /* :: */[
+                      /* Padding */Block.__(18, [/* Px */Block.__(0, [20])]),
+                      /* [] */0
+                    ]);
+                return Jest.Expect[/* toMatchSnapshot */16](Jest.Expect[/* expect */0](serialized_global_cache(/* () */0)));
+              }));
+        return Jest.test("splitSelector", (function () {
+                      return Jest.Expect[/* toEqual */12](/* array */[
+                                    ".a",
+                                    " span:hover",
+                                    " &:matches(h1, h2)"
+                                  ])(Jest.Expect[/* expect */0](Nice.splitSelector(".a, span:hover, &:matches(h1, h2)")));
                     }));
       }));
 

--- a/lib/es6/__tests__/nice_test.js
+++ b/lib/es6/__tests__/nice_test.js
@@ -124,8 +124,8 @@ describe("Nice", (function () {
                       return Jest.Expect[/* toEqual */12](/* array */[
                                     ".a",
                                     " span:hover",
-                                    " &:matches(h1, h2)"
-                                  ])(Jest.Expect[/* expect */0](Nice.splitSelector(".a, span:hover, &:matches(h1, h2)")));
+                                    " &:matches(h1, h2, h3, h4)"
+                                  ])(Jest.Expect[/* expect */0](Nice.splitSelector(".a, span:hover, &:matches(h1, h2, h3, h4)")));
                     }));
       }));
 

--- a/lib/es6/src/nice.js
+++ b/lib/es6/src/nice.js
@@ -896,32 +896,47 @@ function string_of_style(param) {
   }
 }
 
-var selectorTokenizer = (/[(),]|"(?:\\.|[^"\n])*"|'(?:\\.|[^'\n])*'|\/\*[\s\S]*?\*\//g);
-
-var splitSelector = (
-    function(selector) {
-      if(selector.indexOf(',') === -1) {
-        return [selector]
-      }
-
-      var indices = [], res = [], inParen = 0, o
-      /*eslint-disable no-cond-assign*/
-      while (o = selectorTokenizer.exec(selector)) {
-      /*eslint-enable no-cond-assign*/
-        switch (o[0]) {
-        case '(': inParen++; break
-        case ')': inParen--; break
-        case ',': if (inParen) break; indices.push(o.index)
-        }
-      }
-      for (o = indices.length; o--;){
-        res.unshift(selector.slice(indices[o] + 1))
-        selector = selector.slice(0, indices[o])
-      }
-      res.unshift(selector)
-      return res
+function split_on_char(sep, s) {
+  var r = /* [] */0;
+  var j = s.length;
+  for(var i = s.length - 1 | 0; i >= 0; --i){
+    if (s.charCodeAt(i) === sep) {
+      r = /* :: */[
+        $$String.sub(s, i + 1 | 0, (j - i | 0) - 1 | 0),
+        r
+      ];
+      j = i;
     }
-    );
+    
+  }
+  return /* :: */[
+          $$String.sub(s, 0, j),
+          r
+        ];
+}
+
+function splitSelector(selector) {
+  var selectorList = split_on_char(/* "," */44, selector);
+  var withLeftParen = List.filter((function (str) {
+            return $$String.contains(str, /* "(" */40);
+          }))(selectorList);
+  var withRightParen = List.filter((function (str) {
+            return $$String.contains(str, /* ")" */41);
+          }))(selectorList);
+  var withParens = List.map2((function (left, right) {
+          return left + ("," + right);
+        }), withLeftParen, withRightParen);
+  var withoutParens = List.filter((function (str) {
+            if ($$String.contains(str, /* "(" */40)) {
+              return /* false */0;
+            } else {
+              return 1 - $$String.contains(str, /* ")" */41);
+            }
+          }))(selectorList);
+  return $$Array.fold_left((function (arr, str) {
+                return $$Array.append(arr, /* array */[str]);
+              }), /* array */[], $$Array.of_list(List.append(withoutParens, withParens)));
+}
 
 var replace = (
   function(src, _with){
@@ -937,7 +952,7 @@ function join_selectors(a, b) {
               } else {
                 return "&" + a;
               }
-            }), Curry._1(splitSelector, a)));
+            }), splitSelector(a)));
   var bx = $$Array.to_list($$Array.map((function (b) {
               var match = $$String.contains(b, /* "&" */38);
               if (match !== 0) {
@@ -945,7 +960,7 @@ function join_selectors(a, b) {
               } else {
                 return "&" + b;
               }
-            }), Curry._1(splitSelector, b)));
+            }), splitSelector(b)));
   return $$String.concat(",", List.fold_left((function (arr, b) {
                     return List.concat(/* :: */[
                                 arr,
@@ -1338,7 +1353,7 @@ export {
   string_of_writingDirection    ,
   string_of_resizeMode          ,
   string_of_style               ,
-  selectorTokenizer             ,
+  split_on_char                 ,
   splitSelector                 ,
   replace                       ,
   join_selectors                ,

--- a/lib/es6/src/nice.js
+++ b/lib/es6/src/nice.js
@@ -896,46 +896,67 @@ function string_of_style(param) {
   }
 }
 
-function split_on_char(sep, s) {
-  var r = /* [] */0;
-  var j = s.length;
-  for(var i = s.length - 1 | 0; i >= 0; --i){
-    if (s.charCodeAt(i) === sep) {
-      r = /* :: */[
-        $$String.sub(s, i + 1 | 0, (j - i | 0) - 1 | 0),
-        r
-      ];
-      j = i;
-    }
-    
-  }
-  return /* :: */[
-          $$String.sub(s, 0, j),
-          r
-        ];
-}
-
 function splitSelector(selector) {
-  var selectorList = split_on_char(/* "," */44, selector);
-  var withLeftParen = List.filter((function (str) {
-            return $$String.contains(str, /* "(" */40);
-          }))(selectorList);
-  var withRightParen = List.filter((function (str) {
-            return $$String.contains(str, /* ")" */41);
-          }))(selectorList);
-  var withParens = List.map2((function (left, right) {
-          return left + ("," + right);
-        }), withLeftParen, withRightParen);
-  var withoutParens = List.filter((function (str) {
-            if ($$String.contains(str, /* "(" */40)) {
-              return /* false */0;
-            } else {
-              return 1 - $$String.contains(str, /* ")" */41);
-            }
-          }))(selectorList);
-  return $$Array.fold_left((function (arr, str) {
-                return $$Array.append(arr, /* array */[str]);
-              }), /* array */[], $$Array.of_list(List.append(withoutParens, withParens)));
+  var size = selector.length;
+  var _start = 0;
+  var _length = 0;
+  var _depth = 0;
+  var _res = /* array */[];
+  while(true) {
+    var res = _res;
+    var depth = _depth;
+    var length = _length;
+    var start = _start;
+    var index = start + length | 0;
+    var isPastEnd = +(index >= size);
+    if (isPastEnd && length > 0) {
+      return $$Array.append(res, /* array */[$$String.sub(selector, start, length)]);
+    } else if (isPastEnd) {
+      return res;
+    } else {
+      var match = selector.charCodeAt(start + length | 0);
+      var exit = 0;
+      var switcher = match - 40 | 0;
+      if (switcher > 4 || switcher < 0) {
+        exit = 1;
+      } else {
+        switch (switcher) {
+          case 0 : 
+              _depth = depth + 1 | 0;
+              _length = length + 1 | 0;
+              continue ;
+              case 1 : 
+              _depth = depth - 1 | 0;
+              _length = length + 1 | 0;
+              continue ;
+              case 2 : 
+          case 3 : 
+              exit = 1;
+              break;
+          case 4 : 
+              if (depth !== 0) {
+                exit = 1;
+              } else {
+                var res$1 = $$Array.append(res, /* array */[$$String.sub(selector, start, length)]);
+                _res = res$1;
+                _depth = 0;
+                _length = 0;
+                _start = (start + length | 0) + 1 | 0;
+                continue ;
+                
+              }
+              break;
+          
+        }
+      }
+      if (exit === 1) {
+        _length = length + 1 | 0;
+        continue ;
+        
+      }
+      
+    }
+  };
 }
 
 var replace = (
@@ -1353,7 +1374,6 @@ export {
   string_of_writingDirection    ,
   string_of_resizeMode          ,
   string_of_style               ,
-  split_on_char                 ,
   splitSelector                 ,
   replace                       ,
   join_selectors                ,

--- a/lib/js/__tests__/nice_test.js
+++ b/lib/js/__tests__/nice_test.js
@@ -113,12 +113,19 @@ describe("Nice", (function () {
                                 serialized_rule_cache(/* () */0)
                               ]));
               }));
-        return Jest.test("global", (function () {
-                      Nice.$$global("html, body", /* :: */[
-                            /* Padding */Block.__(18, [/* Px */Block.__(0, [20])]),
-                            /* [] */0
-                          ]);
-                      return Jest.Expect[/* toMatchSnapshot */16](Jest.Expect[/* expect */0](serialized_global_cache(/* () */0)));
+        Jest.test("global", (function () {
+                Nice.$$global("html, body", /* :: */[
+                      /* Padding */Block.__(18, [/* Px */Block.__(0, [20])]),
+                      /* [] */0
+                    ]);
+                return Jest.Expect[/* toMatchSnapshot */16](Jest.Expect[/* expect */0](serialized_global_cache(/* () */0)));
+              }));
+        return Jest.test("splitSelector", (function () {
+                      return Jest.Expect[/* toEqual */12](/* array */[
+                                    ".a",
+                                    " span:hover",
+                                    " &:matches(h1, h2)"
+                                  ])(Jest.Expect[/* expect */0](Nice.splitSelector(".a, span:hover, &:matches(h1, h2)")));
                     }));
       }));
 

--- a/lib/js/__tests__/nice_test.js
+++ b/lib/js/__tests__/nice_test.js
@@ -124,8 +124,8 @@ describe("Nice", (function () {
                       return Jest.Expect[/* toEqual */12](/* array */[
                                     ".a",
                                     " span:hover",
-                                    " &:matches(h1, h2)"
-                                  ])(Jest.Expect[/* expect */0](Nice.splitSelector(".a, span:hover, &:matches(h1, h2)")));
+                                    " &:matches(h1, h2, h3, h4)"
+                                  ])(Jest.Expect[/* expect */0](Nice.splitSelector(".a, span:hover, &:matches(h1, h2, h3, h4)")));
                     }));
       }));
 

--- a/lib/js/src/nice.js
+++ b/lib/js/src/nice.js
@@ -896,32 +896,47 @@ function string_of_style(param) {
   }
 }
 
-var selectorTokenizer = (/[(),]|"(?:\\.|[^"\n])*"|'(?:\\.|[^'\n])*'|\/\*[\s\S]*?\*\//g);
-
-var splitSelector = (
-    function(selector) {
-      if(selector.indexOf(',') === -1) {
-        return [selector]
-      }
-
-      var indices = [], res = [], inParen = 0, o
-      /*eslint-disable no-cond-assign*/
-      while (o = selectorTokenizer.exec(selector)) {
-      /*eslint-enable no-cond-assign*/
-        switch (o[0]) {
-        case '(': inParen++; break
-        case ')': inParen--; break
-        case ',': if (inParen) break; indices.push(o.index)
-        }
-      }
-      for (o = indices.length; o--;){
-        res.unshift(selector.slice(indices[o] + 1))
-        selector = selector.slice(0, indices[o])
-      }
-      res.unshift(selector)
-      return res
+function split_on_char(sep, s) {
+  var r = /* [] */0;
+  var j = s.length;
+  for(var i = s.length - 1 | 0; i >= 0; --i){
+    if (s.charCodeAt(i) === sep) {
+      r = /* :: */[
+        $$String.sub(s, i + 1 | 0, (j - i | 0) - 1 | 0),
+        r
+      ];
+      j = i;
     }
-    );
+    
+  }
+  return /* :: */[
+          $$String.sub(s, 0, j),
+          r
+        ];
+}
+
+function splitSelector(selector) {
+  var selectorList = split_on_char(/* "," */44, selector);
+  var withLeftParen = List.filter((function (str) {
+            return $$String.contains(str, /* "(" */40);
+          }))(selectorList);
+  var withRightParen = List.filter((function (str) {
+            return $$String.contains(str, /* ")" */41);
+          }))(selectorList);
+  var withParens = List.map2((function (left, right) {
+          return left + ("," + right);
+        }), withLeftParen, withRightParen);
+  var withoutParens = List.filter((function (str) {
+            if ($$String.contains(str, /* "(" */40)) {
+              return /* false */0;
+            } else {
+              return 1 - $$String.contains(str, /* ")" */41);
+            }
+          }))(selectorList);
+  return $$Array.fold_left((function (arr, str) {
+                return $$Array.append(arr, /* array */[str]);
+              }), /* array */[], $$Array.of_list(List.append(withoutParens, withParens)));
+}
 
 var replace = (
   function(src, _with){
@@ -937,7 +952,7 @@ function join_selectors(a, b) {
               } else {
                 return "&" + a;
               }
-            }), Curry._1(splitSelector, a)));
+            }), splitSelector(a)));
   var bx = $$Array.to_list($$Array.map((function (b) {
               var match = $$String.contains(b, /* "&" */38);
               if (match !== 0) {
@@ -945,7 +960,7 @@ function join_selectors(a, b) {
               } else {
                 return "&" + b;
               }
-            }), Curry._1(splitSelector, b)));
+            }), splitSelector(b)));
   return $$String.concat(",", List.fold_left((function (arr, b) {
                     return List.concat(/* :: */[
                                 arr,
@@ -1337,7 +1352,7 @@ exports.string_of_textDecorationStyle = string_of_textDecorationStyle;
 exports.string_of_writingDirection    = string_of_writingDirection;
 exports.string_of_resizeMode          = string_of_resizeMode;
 exports.string_of_style               = string_of_style;
-exports.selectorTokenizer             = selectorTokenizer;
+exports.split_on_char                 = split_on_char;
 exports.splitSelector                 = splitSelector;
 exports.replace                       = replace;
 exports.join_selectors                = join_selectors;

--- a/lib/js/src/nice.js
+++ b/lib/js/src/nice.js
@@ -896,46 +896,67 @@ function string_of_style(param) {
   }
 }
 
-function split_on_char(sep, s) {
-  var r = /* [] */0;
-  var j = s.length;
-  for(var i = s.length - 1 | 0; i >= 0; --i){
-    if (s.charCodeAt(i) === sep) {
-      r = /* :: */[
-        $$String.sub(s, i + 1 | 0, (j - i | 0) - 1 | 0),
-        r
-      ];
-      j = i;
-    }
-    
-  }
-  return /* :: */[
-          $$String.sub(s, 0, j),
-          r
-        ];
-}
-
 function splitSelector(selector) {
-  var selectorList = split_on_char(/* "," */44, selector);
-  var withLeftParen = List.filter((function (str) {
-            return $$String.contains(str, /* "(" */40);
-          }))(selectorList);
-  var withRightParen = List.filter((function (str) {
-            return $$String.contains(str, /* ")" */41);
-          }))(selectorList);
-  var withParens = List.map2((function (left, right) {
-          return left + ("," + right);
-        }), withLeftParen, withRightParen);
-  var withoutParens = List.filter((function (str) {
-            if ($$String.contains(str, /* "(" */40)) {
-              return /* false */0;
-            } else {
-              return 1 - $$String.contains(str, /* ")" */41);
-            }
-          }))(selectorList);
-  return $$Array.fold_left((function (arr, str) {
-                return $$Array.append(arr, /* array */[str]);
-              }), /* array */[], $$Array.of_list(List.append(withoutParens, withParens)));
+  var size = selector.length;
+  var _start = 0;
+  var _length = 0;
+  var _depth = 0;
+  var _res = /* array */[];
+  while(true) {
+    var res = _res;
+    var depth = _depth;
+    var length = _length;
+    var start = _start;
+    var index = start + length | 0;
+    var isPastEnd = +(index >= size);
+    if (isPastEnd && length > 0) {
+      return $$Array.append(res, /* array */[$$String.sub(selector, start, length)]);
+    } else if (isPastEnd) {
+      return res;
+    } else {
+      var match = selector.charCodeAt(start + length | 0);
+      var exit = 0;
+      var switcher = match - 40 | 0;
+      if (switcher > 4 || switcher < 0) {
+        exit = 1;
+      } else {
+        switch (switcher) {
+          case 0 : 
+              _depth = depth + 1 | 0;
+              _length = length + 1 | 0;
+              continue ;
+              case 1 : 
+              _depth = depth - 1 | 0;
+              _length = length + 1 | 0;
+              continue ;
+              case 2 : 
+          case 3 : 
+              exit = 1;
+              break;
+          case 4 : 
+              if (depth !== 0) {
+                exit = 1;
+              } else {
+                var res$1 = $$Array.append(res, /* array */[$$String.sub(selector, start, length)]);
+                _res = res$1;
+                _depth = 0;
+                _length = 0;
+                _start = (start + length | 0) + 1 | 0;
+                continue ;
+                
+              }
+              break;
+          
+        }
+      }
+      if (exit === 1) {
+        _length = length + 1 | 0;
+        continue ;
+        
+      }
+      
+    }
+  };
 }
 
 var replace = (
@@ -1352,7 +1373,6 @@ exports.string_of_textDecorationStyle = string_of_textDecorationStyle;
 exports.string_of_writingDirection    = string_of_writingDirection;
 exports.string_of_resizeMode          = string_of_resizeMode;
 exports.string_of_style               = string_of_style;
-exports.split_on_char                 = split_on_char;
 exports.splitSelector                 = splitSelector;
 exports.replace                       = replace;
 exports.join_selectors                = join_selectors;


### PR DESCRIPTION
This is a start to implement the `splitSelector` function in pure Reason and addresses #9.

Do you want it to work if compiled to native or is it still OK if it only compiles to JavaScript?

Any formatting change is from `refmt` that I don't know how to turn off.